### PR TITLE
Modifications to support PETSC_v3.23.6

### DIFF
--- a/fortran/version3/PETScVersions.F90
+++ b/fortran/version3/PETScVersions.F90
@@ -2,6 +2,7 @@
 ! has changed from version to version.
   
 #include <petscversion.h>
+#include <petsc/finclude/petsctime.h>
 
 ! For PETSc versions prior to 3.3, the MatCreateAIJ subroutine was called MatCreateMPIAIJ.
 #if (PETSC_VERSION_MAJOR < 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR < 3))
@@ -41,6 +42,21 @@
 #define PCFactorSetUpMatSolverType PCFactorSetUpMatSolverPackage
 #endif
 !Hereafter in this code, use MatSolverType.
+
+! For PETSc versions prior to 3.19, the VecRestoreArray subroutine was called VecRestoreArrayF90.
+#if (PETSC_VERSION_MAJOR < 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR < 19))
+#define VecRestoreArray VecRestoreArrayF90
+#endif
+! Hereafter in this code, use VecRestoreArray.
+
+! For PETSc versions prior to 3.23, the VecGetArray subroutine was called VecGetArrayF90.
+#if (PETSC_VERSION_MAJOR < 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR < 23))
+#define VecGetArray VecGetArrayF90
+#define PETSC_NULL_INTEGER_ARRAY PETSC_NULL_INTEGER
+#define PETSC_NULL_SCALAR_ARRAY PETSC_NULL_SCALAR
+#define PETSC_NULL_REAL_ARRAY PETSC_NULL_REAL
+#endif
+! Hereafter in this code, use VecGetArray.
 
 ! The remaining code ensures that the proper PETSc include files and modules are included in every subroutine by including just one line:
 ! #include "PETScVersions.F90"

--- a/fortran/version3/adjointDiagnostics.F90
+++ b/fortran/version3/adjointDiagnostics.F90
@@ -103,7 +103,7 @@ implicit none
           call VecScatterEnd(VecScatterContext, deltaF, deltaFOnProc0, INSERT_VALUES, SCATTER_FORWARD, ierr)
           if (masterProc) then
             ! Convert the PETSc vector into a normal Fortran array
-            call VecGetArrayF90(deltaFOnProc0, deltaFArray, ierr)
+            call VecGetArray(deltaFOnProc0, deltaFArray, ierr)
           end if
 
           ! Scatter deltaG to master proc
@@ -112,7 +112,7 @@ implicit none
           call VecScatterEnd(VecScatterContext, deltaG, deltaGOnProc0, INSERT_VALUES, SCATTER_FORWARD, ierr)
           if (masterProc) then
             ! Convert the PETSc vector into a normal Fortran array
-            call VecGetArrayF90(deltaGOnProc0, deltaGArray, ierr)
+            call VecGetArray(deltaGOnProc0, deltaGArray, ierr)
           end if
 
           if (masterProc) then
@@ -210,7 +210,7 @@ implicit none
     call VecScatterEnd(VecScatterContext, forwardSolution, forwardSolutionOnProc0, INSERT_VALUES, SCATTER_FORWARD, ierr)
     if (masterProc) then
       ! Convert the PETSc vector into a normal Fortran array
-      call VecGetArrayF90(forwardSolutionOnProc0, forwardSolutionArray, ierr)
+      call VecGetArray(forwardSolutionOnProc0, forwardSolutionArray, ierr)
     end if
 
         if (whichLambda==1) then ! BHat
@@ -348,7 +348,7 @@ end do
     call VecScatterEnd(VecScatterContext, deltaF, deltaFOnProc0, INSERT_VALUES, SCATTER_FORWARD, ierr)
     if (masterProc) then
       ! Convert the PETSc vector into a normal Fortran array
-      call VecGetArrayF90(deltaFOnProc0, deltaFArray, ierr)
+      call VecGetArray(deltaFOnProc0, deltaFArray, ierr)
     end if
 
         if (whichLambda==1) then ! BHat
@@ -486,7 +486,7 @@ end do
     call VecScatterEnd(VecScatterContext, deltaF, deltaFOnProc0, INSERT_VALUES, SCATTER_FORWARD, ierr)
     if (masterProc) then
       ! Convert the PETSc vector into a normal Fortran array
-      call VecGetArrayF90(deltaFOnProc0, deltaFArray, ierr)
+      call VecGetArray(deltaFOnProc0, deltaFArray, ierr)
     end if
 
     if (whichSpecies == 0) then

--- a/fortran/version3/evaluateResidual.F90
+++ b/fortran/version3/evaluateResidual.F90
@@ -286,7 +286,8 @@
           print *,"Saving residual in matlab format: ",trim(filename)
        end if
        call PetscViewerASCIIOpen(MPIComm, trim(filename), viewer, ierr)
-       call PetscViewerSetFormat(viewer, PETSC_VIEWER_ASCII_MATLAB, ierr)
+       !call PetscViewerSetFormat(viewer, PETSC_VIEWER_ASCII_MATLAB, ierr) ! Depricated
+       call PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_MATLAB, ierr)
 
        call PetscObjectSetName(residualVec, "residual", ierr)
        call VecView(residualVec, viewer, ierr)

--- a/fortran/version3/populatedMatrixdLambda.F90
+++ b/fortran/version3/populatedMatrixdLambda.F90
@@ -30,7 +30,6 @@
     PetscScalar, dimension(:,:), allocatable :: xPartOfXDot, xPartOfXDot_plus, xPartOfXDot_minus
     integer :: ix_row, ix_col, rowIndex, colIndex, ell
     PetscLogDouble :: time1, time2
-    double precision :: myMatInfo(MAT_INFO_SIZE)
     integer :: NNZ, NNZAllocated, NMallocs
     PetscScalar :: dBHatdLambda, dBHat_sub_thetadLambda, dBHat_sub_zetadLambda, dBHat_sup_thetadLambda
     PetscScalar :: dBHat_sup_zetadLambda, dBHatdthetadLambda, dBHatdzetadLambda, dDHatdLambda

--- a/fortran/version3/sfincs_main.F90
+++ b/fortran/version3/sfincs_main.F90
@@ -44,7 +44,7 @@ module sfincs_main
        end if
     end if
     
-    call PetscTime(time1, ierr)
+    !call petsctime(time1, ierr)
     startTime = time1
     
     call readNamelistInput()

--- a/fortran/version3/solver.F90
+++ b/fortran/version3/solver.F90
@@ -22,6 +22,7 @@ contains
     PC :: preconditionerContext, preconditionerContext_adjoint
     integer :: numRHSs
     SNESConvergedReason :: reason
+    integer :: reason_int
     KSPConvergedReason :: KSPReason
     PetscLogDouble :: time1, time2
     integer :: userContext(1)
@@ -442,7 +443,7 @@ contains
              print *,"Beginning the main solve.  This could take a while ..."
           end if
 
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
           if (solveSystem) then
 #if (PETSC_VERSION_MAJOR > 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR >= 8))
              call SNESSolve(mysnes,PETSC_NULL_VEC, solutionVec, ierr)
@@ -468,19 +469,20 @@ contains
 #endif
           end if
 
-          call PetscTime(time2, ierr)
+          !call petsctime(time2, ierr)
           if (masterProc) then
              print *,"Done with the main solve.  Time to solve: ", time2-time1, " seconds."
           end if
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
 
-          !!if (includePhi1) then !!Commented by AM 2018-12
+          !if (includePhi1) then !!Commented by AM 2018-12
           if (includePhi1 .and. (.not. readExternalPhi1)) then !!Added by AM 2018-12
              call SNESGetConvergedReason(mysnes, reason, ierr)
-             if (reason>0) then
+             reason_int = reason%v
+             if (reason_int>0) then
                 if (masterProc) then
                    print *,"Nonlinear iteration (SNES) converged!  SNESConvergedReason = ", reason
-                   select case (reason)
+                   select case (reason_int)
                    case (2)
                       print *,"  SNES_CONVERGED_FNORM_ABS: ||F|| < atol"
                    case (3)
@@ -497,7 +499,7 @@ contains
              else
                 if (masterProc) then
                    print *,"Nonlinear iteration (SNES) did not converge :(   SNESConvergedReason = ", reason
-                   select case (reason)
+                   select case (reason_int)
                    case (-1)
                       print *,"  SNES_DIVERGED_FUNCTION_DOMAIN: The new x location passed the function is not in the domain of F"
                    case (-2)
@@ -627,17 +629,17 @@ contains
                 print *,"Beginning the main solve.  This could take a while ..."
              end if
 
-             call PetscTime(time1, ierr)
+             !call petsctime(time1, ierr)
              if (solveSystem) then
                 ! All the magic happens in this next line!
                 call KSPSolve(KSPInstance,residualVec, solutionVec, ierr)
              end if
 
-             call PetscTime(time2, ierr)
+             !call petsctime(time2, ierr)
              if (masterProc) then
                 print *,"Done with the main solve.  Time to solve: ", time2-time1, " seconds."
              end if
-             call PetscTime(time1, ierr)
+             !call petsctime(time1, ierr)
 
              call checkIfKSPConverged(KSPInstance)
 
@@ -696,7 +698,7 @@ contains
          print *,"Beginning the adjoint solve.  This could take a while ..."
       end if
 
-      call PetscTime(time1, ierr)
+      !call petsctime(time1, ierr)
       if (solveSystem) then
         if (discreteAdjointOption .eqv. .false.) then
           call KSPSolve(KSPInstance_adjoint,adjointRHSVec,adjointSolutionJr, ierr)
@@ -707,11 +709,11 @@ contains
         end if
       end if
 
-      call PetscTime(time2, ierr)
+      !call petsctime(time2, ierr)
       if (masterProc) then
          print *,"Done with the adjoint solve.  Time to solve: ", time2-time1, " seconds."
       end if
-      call PetscTime(time1, ierr)
+      !call petsctime(time1, ierr)
 
       if (ambipolarSolve .and. (ambipolarSolveOption == 1 .or. ambipolarSolveOption == 3) .and. RHSMode < 3) then
         call computedRadialCurrentdEr(solutionVec,adjointSolutionJr)
@@ -818,7 +820,7 @@ contains
              print *,"Beginning the adjoint solve.  This could take a while ..."
           end if
 
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
           if (solveSystem) then
             if (discreteAdjointOption .eqv. .false.) then
               call KSPSolve(KSPInstance_adjoint,adjointRHSVec,adjointSolutionVec, ierr)
@@ -829,15 +831,15 @@ contains
             end if
           end if
 
-          call PetscTime(time2, ierr)
+          !call petsctime(time2, ierr)
           if (masterProc) then
              print *,"Done with the adjoint solve.  Time to solve: ", time2-time1, " seconds."
           end if
 
           !> Compute diagnostics for species-specific fluxes
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
           call evaluateDiagnostics(solutionVec, adjointSolutionVec,adjointSolutionJr,whichAdjointRHS,ispecies)
-          call PetscTime(time2, ierr)
+          !call petsctime(time2, ierr)
           if (masterProc) then
             print *,"Done with the adjoint diagnostics.  Time: ", time2-time1, " seconds."
           end if
@@ -863,9 +865,9 @@ contains
 
         ! Now compute diagnostics for species-summed quantities
         if (useSummedSolutionVec) then
-            call PetscTime(time1, ierr)
+            !call petsctime(time1, ierr)
             call evaluateDiagnostics(solutionVec,summedSolutionVec,adjointSolutionJr,whichAdjointRHS,0)
-            call PetscTime(time2, ierr)
+            !call petsctime(time2, ierr)
             if (masterProc) then
               print *,"Done with the adjoint diagnostics.  Time: ", time2-time1, " seconds."
             end if
@@ -920,7 +922,7 @@ contains
              print *,"Beginning the adjoint solve.  This could take a while ..."
           end if
 
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
           if (solveSystem) then
              if (discreteAdjointOption .eqv. .false.) then
              ! All the magic happens in this next line!
@@ -931,14 +933,14 @@ contains
                 call checkIfKSPConverged(KSPInstance)
              end if
           end if
-          call PetscTime(time2, ierr)
+          !call petsctime(time2, ierr)
           if (masterProc) then
              print *,"Done with the adjoint solve.  Time to solve: ", time2-time1, " seconds."
           end if
 
-          call PetscTime(time1, ierr)
+          !call petsctime(time1, ierr)
           call evaluateDiagnostics(solutionVec, adjointSolutionVec, adjointSolutionJr, whichAdjointRHS, ispecies)
-          call PetscTime(time2, ierr)
+          !call petsctime(time2, ierr)
           if (masterProc) then
             print *,"Done with the adjoint diagnostics.  Time: ", time2-time1, " seconds."
           end if

--- a/fortran/version3/testingAdjointDiagnostics.F90
+++ b/fortran/version3/testingAdjointDiagnostics.F90
@@ -89,14 +89,14 @@ module testingAdjointDiagnostics
       adjointRadialCurrentOption = .true.
     end if
 
-    call PetscTime(time1, ierr)
+    !call petsctime(time1, ierr)
     if (constantJr) then
       ambipolarSolve = .true.
       call mainAmbipolarSolver()
     else
       call mainSolverLoop()
     end if
-    call PetscTime(time2, ierr)
+    !call petsctime(time2, ierr)
     if (masterProc) then
       print *,"Time for adjoint solve: ", time2-time1
     end if
@@ -122,7 +122,7 @@ module testingAdjointDiagnostics
 
     ! Set RHSMode = 1 so call to solver does not include adjoint solve
     RHSMode = 1
-    call PetscTime(time1, ierr)
+    !call petsctime(time1, ierr)
     do whichLambda = 1, NLambdas
       if (whichLambda .ne. 1) then
         this_NmodesAdjoint = 1
@@ -172,7 +172,7 @@ module testingAdjointDiagnostics
     call updateBoozerGeometry(whichMode, whichLambda, .true.)
       end do ! whichMode
     end do ! whichLambda
-    call PetscTime(time2, ierr)
+    !call petsctime(time2, ierr)
     if (masterProc) then
       print *,"Time for finite difference: ", time2-time1
     end if


### PR DESCRIPTION
This pull request fixes a bunch of issues which cropped up when trying to build against PETSc 3.26.3.  The only fix which probably needs work is that for whatever reason I could not link to `petsctime`.   Therefor I've just commented those lines. It should still compile against older versions just fine.