### PR TITLE
Add pure Nix flake for version3 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ sfincsBinary*
 .DS_Store
 sfincsJob*
 slurm-*
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,8 @@
       hdf5 = pkgs.hdf5-fortran;
       netcdf = pkgs.netcdf;
       netcdffortran = pkgs.netcdffortran;
+      python = pkgs.python3;
+      hdf5Tools = pkgs.hdf5;
       buildTools = [
         pkgs.gnumake
         pkgs.pkg-config
@@ -91,9 +93,14 @@
         version = "unstable";
         src = ./.;
         strictDeps = true;
+        doCheck = true;
 
         nativeBuildInputs = buildTools;
         buildInputs = buildLibs;
+        nativeCheckInputs = [
+          python
+          hdf5Tools
+        ];
         configurePhase = ":";
 
         buildPhase = ''
@@ -101,6 +108,14 @@
           export SFINCS_SYSTEM=nix
           make -C fortran/version3 clean
           make -C fortran/version3 -j$NIX_BUILD_CORES
+        '';
+
+        checkPhase = ''
+          ${commonEnv}
+          export SFINCS_SYSTEM=nix
+          patchShebangs fortran/version3/examples
+          find fortran/version3/examples -name 'job.CI' -execdir ln -sf job.CI job.nix ';'
+          make -C fortran/version3 test
         '';
 
         installPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  description = "Minimal Nix flake for building SFINCS version3";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      mpi = pkgs.openmpi;
+      mpiDev = pkgs.openmpi.dev;
+      scalapack = pkgs.scalapack;
+      scotch = pkgs.scotch.overrideAttrs (old: rec {
+        version = "7.0.3";
+        src = pkgs.fetchFromGitLab {
+          domain = "gitlab.inria.fr";
+          owner = "scotch";
+          repo = "scotch";
+          rev = "v${version}";
+          sha256 = "0krs485gsf6vlhgkh2w96mspbmysmsalj4cnnjp9xk63w39qgcy2";
+        };
+      });
+      mumps = (pkgs.mumps.override {
+        inherit scotch;
+        mpiSupport = true;
+        withPtScotch = true;
+      }).overrideAttrs (old: rec {
+        version = "5.6.2";
+        src = pkgs.fetchzip {
+          url = "https://mumps-solver.org/MUMPS_${version}.tar.gz";
+          sha256 = "1dwx4virk4a53pk5ny3v88c3xa8d3ym7157x63cqyq5qky6hy67m";
+        };
+      });
+      petsc = (pkgs.petsc.override {
+        hdf5-support = true;
+        petsc-optimized = true;
+      }).overrideAttrs (old: rec {
+        version = "3.21.1";
+        src = pkgs.fetchzip {
+          url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${version}.tar.gz";
+          sha256 = "12nczdxk61vy7gr73p8xbfpwic504v713285xhhrb8qabw6135pr";
+        };
+        buildInputs = old.buildInputs ++ [
+          mumps
+          scalapack
+          scotch
+        ];
+        configureFlags = old.configureFlags ++ [
+          "--with-mumps-include=${mumps}/include"
+          "--with-mumps-lib=[${mumps}/lib/libdmumps.so,${mumps}/lib/libmumps_common.so,${mumps}/lib/libpord.so]"
+          "--with-scalapack-lib=${scalapack}/lib/libscalapack.so"
+        ];
+      });
+      hdf5 = pkgs.hdf5-fortran;
+      netcdf = pkgs.netcdf;
+      netcdffortran = pkgs.netcdffortran;
+      buildTools = [
+        pkgs.gnumake
+        pkgs.pkg-config
+        mpiDev
+        netcdf
+        netcdffortran
+      ];
+      buildLibs = [
+        mpi
+        petsc
+        mumps
+        scalapack
+        scotch
+        hdf5
+        hdf5.dev
+        netcdf
+        netcdffortran
+        pkgs.curl
+        pkgs.zlib
+      ];
+      commonEnv = ''
+        export PETSC_DIR=${petsc}
+        export PETSC_ARCH=
+        export PATH=${mpiDev}/bin:${mpi}/bin:${netcdffortran}/bin:${netcdf}/bin:$PATH
+        export PKG_CONFIG_PATH=${petsc}/lib/pkgconfig:${hdf5.dev}/lib/pkgconfig:$PKG_CONFIG_PATH
+      '';
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = buildTools ++ buildLibs;
+        shellHook = commonEnv;
+      };
+
+      packages.${system}.default = pkgs.stdenv.mkDerivation {
+        pname = "sfincs-version3";
+        version = "unstable";
+        src = ./.;
+        strictDeps = true;
+
+        nativeBuildInputs = buildTools;
+        buildInputs = buildLibs;
+        configurePhase = ":";
+
+        buildPhase = ''
+          ${commonEnv}
+          export SFINCS_SYSTEM=nix
+          make -C fortran/version3 clean
+          make -C fortran/version3 -j$NIX_BUILD_CORES
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp fortran/version3/sfincs $out/bin/
+        '';
+      };
+    };
+}

--- a/fortran/version3/makefiles/makefile.nix
+++ b/fortran/version3/makefiles/makefile.nix
@@ -1,0 +1,38 @@
+# -*- mode: makefile -*-
+#
+# This makefile is used for Nix environments configured by flake.nix.
+
+ifndef PETSC_DIR
+$(error PETSC_DIR must be set to the PETSc prefix before building with SFINCS_SYSTEM=nix)
+endif
+
+# These next 2 includes set FC, FLINKER, and PETSC_LIB:
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+FLINKER = mpif90
+
+# The variable LIBSTELL_DIR should either be "mini_libstell", if you use this reduced version of libstell
+# that comes packaged with SFINCS, or else it should point to a directory containing libstell .mod files
+# elsewhere on your system.
+LIBSTELL_DIR=mini_libstell
+
+# The variable LIBSTELL_FOR_SFINCS should either be "mini_libstell/mini_libstell.a", if you use this reduced version of libstell
+# that comes packaged with SFINCS, or else it should point to a libstell.a library elsewhere on your system.
+LIBSTELL_FOR_SFINCS=mini_libstell/mini_libstell.a
+
+PETSC_ARCH_INCLUDE = $(if $(strip $(PETSC_ARCH)),-I${PETSC_DIR}/${PETSC_ARCH}/include)
+
+# Any other flags for compiling, such as -I include flags:
+EXTRA_COMPILE_FLAGS = -I${PETSC_DIR}/include $(PETSC_ARCH_INCLUDE) -ffree-line-length-none -fallow-argument-mismatch $(shell pkg-config --cflags hdf5_fortran) $(shell nf-config --fflags)
+
+# Any other flags for linking, such as -l library flags:
+EXTRA_LINK_FLAGS = $(shell pkg-config --libs hdf5_hl_fortran hdf5_hl) $(shell nf-config --flibs)
+
+# The next parameters are used only for running and testing selected examples using "make test".
+
+# For "make test", are runs submitted using a batch system (such as Slurm)?
+# The value of this variable must be "yes" or "no".
+SFINCS_IS_A_BATCH_SYSTEM_USED=no
+
+# This next line matters only if a batch system is used:
+SFINCS_COMMAND_TO_SUBMIT_JOB=

--- a/fortran/version3/solver.F90
+++ b/fortran/version3/solver.F90
@@ -449,21 +449,29 @@ contains
 #else
              call SNESSolve(mysnes,PETSC_NULL_OBJECT, solutionVec, ierr)
 #endif
-             call MatMumpsGetInfog(factorMat, 1, factor_err, ierr)
 
 #if (PETSC_VERSION_MAJOR < 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR < 5))
              ! No way to automatically control MUMPS for old versions of PETSC.
 #else
-             if (actualSolverType == MATSOLVERMUMPS .and. factor_err .ne. 0 .and. mumps_icntl_14<1024) then
-                ! For now, assume all failures are due to MUMPS.  This might not always be true....
-                ! Try increasing the amount by which the mumps work array can expand due to near-0 pivots.
-                if (masterProc) then
-                   print *,"Mumps INFOG(1) = ",factor_err
-                   print *,"Solve failed, so doubling MUMPS icntl(14), which had been ",mumps_icntl_14
+             ! factorMat is only populated by PCFactorGetMatrix when the selected
+             ! parallel direct solver is MUMPS (see the actualSolverType == MATSOLVERMUMPS
+             ! branch earlier in this routine).  Querying MatMumpsGetInfog on a factorMat
+             ! that belongs to a different solver (e.g. superlu_dist) dereferences
+             ! uninitialised state and segfaults.  Gate the whole MUMPS retry block on
+             ! the actual solver type.
+             if (actualSolverType == MATSOLVERMUMPS) then
+                call MatMumpsGetInfog(factorMat, 1, factor_err, ierr)
+                if (factor_err .ne. 0 .and. mumps_icntl_14 < 1024) then
+                   ! For now, assume all failures are due to MUMPS.  This might not always be true....
+                   ! Try increasing the amount by which the mumps work array can expand due to near-0 pivots.
+                   if (masterProc) then
+                      print *,"Mumps INFOG(1) = ",factor_err
+                      print *,"Solve failed, so doubling MUMPS icntl(14), which had been ",mumps_icntl_14
+                   end if
+                   mumps_icntl_14 = mumps_icntl_14 * 2
+                   ierr = 0
+                   doAnotherSolve = .true.
                 end if
-                mumps_icntl_14 = mumps_icntl_14 * 2
-                ierr = 0
-                doAnotherSolve = .true.
              end if
 #endif
           end if


### PR DESCRIPTION
## Summary

Adds a pure Nix flake for building and testing `fortran/version3` without relying on host packages.

The flake pins the solver stack to versions with direct in-repo provenance:
- PETSc `3.21.1`
- MUMPS `5.6.2`
- Scotch/PT-Scotch `7.0.3`

It also adds `fortran/version3/makefiles/makefile.nix` so the version3 build can use the pinned PETSc/HDF5/NetCDF stack inside the Nix sandbox.

## Verification

```bash
nix build . -L
```

This completed successfully in a pure sandbox, built `fortran/version3/sfincs`, ran `make -C fortran/version3 test` in `checkPhase`, and reported:

```text
ALL TESTS THAT WERE RUN WERE PASSED SUCCESSFULLY.
```

The pure-store result was produced at `result/bin/sfincs`.
