### PR TITLE
solver: guard MatMumpsGetInfog with actualSolverType == MATSOLVERMUMPS

### DIFF
--- a/fortran/version3/solver.F90
+++ b/fortran/version3/solver.F90
@@ -449,21 +449,29 @@ contains
 #else
              call SNESSolve(mysnes,PETSC_NULL_OBJECT, solutionVec, ierr)
 #endif
-             call MatMumpsGetInfog(factorMat, 1, factor_err, ierr)
 
 #if (PETSC_VERSION_MAJOR < 3 || (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR < 5))
              ! No way to automatically control MUMPS for old versions of PETSC.
 #else
-             if (actualSolverType == MATSOLVERMUMPS .and. factor_err .ne. 0 .and. mumps_icntl_14<1024) then
-                ! For now, assume all failures are due to MUMPS.  This might not always be true....
-                ! Try increasing the amount by which the mumps work array can expand due to near-0 pivots.
-                if (masterProc) then
-                   print *,"Mumps INFOG(1) = ",factor_err
-                   print *,"Solve failed, so doubling MUMPS icntl(14), which had been ",mumps_icntl_14
+             ! factorMat is only populated by PCFactorGetMatrix when the selected
+             ! parallel direct solver is MUMPS (see the actualSolverType == MATSOLVERMUMPS
+             ! branch earlier in this routine).  Querying MatMumpsGetInfog on a factorMat
+             ! that belongs to a different solver (e.g. superlu_dist) dereferences
+             ! uninitialised state and segfaults.  Gate the whole MUMPS retry block on
+             ! the actual solver type.
+             if (actualSolverType == MATSOLVERMUMPS) then
+                call MatMumpsGetInfog(factorMat, 1, factor_err, ierr)
+                if (factor_err .ne. 0 .and. mumps_icntl_14 < 1024) then
+                   ! For now, assume all failures are due to MUMPS.  This might not always be true....
+                   ! Try increasing the amount by which the mumps work array can expand due to near-0 pivots.
+                   if (masterProc) then
+                      print *,"Mumps INFOG(1) = ",factor_err
+                      print *,"Solve failed, so doubling MUMPS icntl(14), which had been ",mumps_icntl_14
+                   end if
+                   mumps_icntl_14 = mumps_icntl_14 * 2
+                   ierr = 0
+                   doAnotherSolve = .true.
                 end if
-                mumps_icntl_14 = mumps_icntl_14 * 2
-                ierr = 0
-                doAnotherSolve = .true.
              end if
 #endif
           end if


### PR DESCRIPTION
## Summary

`fortran/version3/solver.F90` calls `MatMumpsGetInfog(factorMat, 1, factor_err, ierr)` unconditionally after `SNESSolve`, but `factorMat` is only populated by `PCFactorGetMatrix(preconditionerContext, factorMat, ierr)` inside the `if (actualSolverType == MATSOLVERMUMPS)` branch earlier in the same routine. When PETSc is built with `superlu_dist` and `whichParallelSolverToFactorPreconditioner=2` is chosen (or MUMPS is unavailable and superlu_dist is auto-selected), `factorMat` is a stale `Mat` handle and PETSc segfaults inside MUMPS-specific code.

The fix extends the existing `actualSolverType == MATSOLVERMUMPS` guard (already applied to the retry body) upward so it also protects the `MatMumpsGetInfog` call. Strict bug fix, no behavioural change on the MUMPS path.

## Root cause

- `solver.F90:29`: `Mat :: factorMat` declared uninitialised.
- `solver.F90:363-378`: `PCFactorGetMatrix(..., factorMat, ...)` assigns `factorMat` only inside `if (actualSolverType == MATSOLVERMUMPS) then ... end if`.
- Pre-patch `solver.F90:452`: `call MatMumpsGetInfog(factorMat, 1, factor_err, ierr)` runs regardless of the selected solver.
- Pre-patch `solver.F90:457`: retry body already gated on `actualSolverType == MATSOLVERMUMPS`, confirming the author intended this whole region to be MUMPS-only.

## Failure evidence (unpatched)

Observed on PETSc 3.21.1 with superlu_dist selected. `stdout.log` reaches:

```
 Solver package which will be used: superlu_dist
 ...
 Saving diagnostics to h5 file for iteration            1
```

Then `stderr.log`:

```
[0]PETSC ERROR: Caught signal number 11 SEGV: Segmentation Violation, probably memory access out of range
[0]PETSC ERROR: ---------------------  Stack Frames ------------------------------------
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
  Errorcode: 59
```

`gdb` backtrace pinpoints `MatMumpsGetInfog` called from `mainSolverLoop`. Transport diagnostics have already been flushed to HDF5 by `diagnosticsMonitor` at this point, confirming the crash is strictly after `SNESSolve` returns, at the unguarded `MatMumpsGetInfog` call.

## Fix evidence (patched)

Rebuilt `fortran/version3/sfincs` from the patched tree via a nix flake (PETSc 3.21.1, MUMPS 5.6.2).

### 1. Full example suite still passes on the MUMPS path

```
...
ALL TESTS THAT WERE RUN WERE PASSED SUCCESSFULLY.
```

19 examples: inductiveE_noEr, tokamak_1species_FPCollisions_*, monoenergetic_geometryScheme{5,11}, geometryScheme4_2species_*, transportMatrix_geometryScheme{2,11}, quick_2species_FPCollisions_noEr.

### 2. Bit-identical diagnostics on a multispecies single-surface prescribed-Er run (MUMPS selected both pre and post patch)

```
FSABjHat (bootstrap current):   -1.9194839969757908E-002     (pre-patch)
FSABjHat (bootstrap current):   -1.9194839969757908E-002     (post-patch)
```

All other physics diagnostics (FSADensityPerturbation, FSABFlow, NTV, particleFlux_vm0_psiHat, particleFlux_vm_psiHat, classicalParticleFlux, classicalHeatFlux, momentumFlux_vm_psiHat, heatFlux_vm0_psiHat, heatFlux_vm_psiHat, particle source, heat source) match bit-for-bit across both species.

### 3. Bit-identical diagnostics on a separate axisymmetric single-surface run

Same pattern on a single axisymmetric surface (`rho_pol = 0.632`, AUG 30835 equilibrium): full diagnostic output identical pre vs. post patch.

## Test plan

- [ ] Confirm the guard does not regress MUMPS behaviour on the in-tree examples that exercise MUMPS as the direct solver.
- [ ] Optional: rerun a `whichParallelSolverToFactorPreconditioner=2` (superlu_dist) case with the pre-patch source to reproduce the segfault, then verify the patched source completes and writes diagnostics.